### PR TITLE
Use `std::to_underlying`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.28)
 
 include(FetchContent)
 # Download the boilerplate for the experimental support for C++ Modules

--- a/src/bits.ixx
+++ b/src/bits.ixx
@@ -14,19 +14,12 @@ namespace gdr::bits {
     export template<typename T>
     concept EnumType = std::is_enum_v<T>;
 
-    // -- Retrieve the underlying numerical representation of an enummeration value.
-    export template<EnumType T>
-    constexpr auto rep(T t)
-    {
-        return static_cast<std::underlying_type_t<T>>(t);
-    }
-
     // -- Same as `rep()`, except the as bag of bits, i.e. unsigned type.
     export template<EnumType T>
-    constexpr auto as_bits(T t)
+    constexpr auto bag(T t)
     {
         using S = std::make_unsigned_t<std::underlying_type_t<T>>;
-        return static_cast<S>(rep(t));
+        return static_cast<S>(std::to_underlying(t));
     }
 
     // -- Bit mask operations on bitmask enums, sequestered in a dedicated namespace.
@@ -34,25 +27,25 @@ namespace gdr::bits {
         export template<EnumType T>
         constexpr T operator&(T x, T y)
         {
-            return static_cast<T>(as_bits(x) & as_bits(y));
+            return static_cast<T>(bits::bag(x) & bits::bag(y));
         }
 
         export template<EnumType T>
         constexpr T operator|(T x, T y)
         {
-            return static_cast<T>(as_bits(x) | as_bits(y));
+            return static_cast<T>(bits::bag(x) | bits::bag(y));
         }
 
         export template<EnumType T>
         constexpr T operator^(T x, T y)
         {
-            return static_cast<T>(as_bits(x) ^ as_bits(y));
+            return static_cast<T>(bits::bag(x) ^ bits::bag(y));
         }
 
         export template<EnumType T>
         constexpr T operator~(T x)
         {
-            return static_cast<T>(~as_bits(x));
+            return static_cast<T>(~bits::bag(x));
         }
     }
 }


### PR DESCRIPTION
Now available in C++23.

- Remove `gdr::bits::rep` in favor of `std::to_underlying`.

- Rename `gdr::bits::as_bits` to `gdr::bits::bag`.