### PR TITLE
Require CMake version >= 3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,33 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.31)
 
-include(FetchContent)
-# Download the boilerplate for the experimental support for C++ Modules
-FetchContent_Declare(
-    cmake-for-modules
-    GIT_REPOSITORY https://github.com/GabrielDosReis/cmake-for-modules
-    GIT_TAG main
-)
-
-FetchContent_MakeAvailable(cmake-for-modules)
-
-project(bits CXX)
+project(gdr-bits-utility CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Default to Release build type
-if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_BUILD_TYPE "Release")
-endif()
+include(GNUInstallDirs)
 
-list(PREPEND CMAKE_MODULE_PATH "${cmake-for-modules_SOURCE_DIR}")
-include(CXXModuleExperimentalSupport)
-
-add_library(gdr-bits)
-target_sources(gdr-bits
-    PUBLIC 
+add_library(gdr-bits-utility)
+target_compile_features(gdr-bits-utility PUBLIC cxx_std_23)
+target_sources(gdr-bits-utility
+    PUBLIC
         FILE_SET CXX_MODULES
-        FILES
-            src/bits.ixx
+            BASE_DIRS src
+            FILES src/bits.ixx
 )
 
-target_link_libraries(gdr-bits cxx-std-modules)
+
+# Everyone else targets this library as `GDR:BitsUtility`.
+add_library(GDR.Bits::Utility ALIAS gdr-bits-utility)
+
+install(TARGETS gdr-bits-utility
+    EXPORT GDR.Bits.Utility
+    FILE_SET CXX_MODULES
+        DESTINATION modules/gdr
+)
+
+install(EXPORT GDR.Bits.Utility
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GDR.Bits.Utility
+    NAMESPACE GDR.Bits::
+    FILE targets.cmake
+    CXX_MODULES_DIRECTORY .
+)


### PR DESCRIPTION
Rely on CMake 3.31's support for `import std`.