### PR TITLE
Explicitly tell CMake to activate module std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.31)
 project(gdr-bits-utility CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_MODULE_STD 1)     # Hopefully this is automatically set by future CMake
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Support for `import std;` is till experimental in CMake 3.31.  That requires explicitly telling it to activate support for it.